### PR TITLE
Fix LeakCanary activity retention paths

### DIFF
--- a/WildBridgeApp/android-sdk-v5-sample/src/main/java/dji/sampleV5/aircraft/WildBridgeDefaultLayoutActivity.kt
+++ b/WildBridgeApp/android-sdk-v5-sample/src/main/java/dji/sampleV5/aircraft/WildBridgeDefaultLayoutActivity.kt
@@ -247,6 +247,7 @@ class WildBridgeDefaultLayoutActivity : DefaultLayoutActivity() {
 
     // ==================== AutoSensing (AI Detection) ====================
     private var isAutoSensingActive = false
+    private var isAutoSensingListenerRegistered = false
     @Volatile private var currentDetectedTargets: List<DetectedTarget> = emptyList()
     private var detectionOverlay: DetectionOverlayView? = null
 
@@ -702,13 +703,19 @@ class WildBridgeDefaultLayoutActivity : DefaultLayoutActivity() {
     private fun startAutoSensing() {
         if (isAutoSensingActive) return
         try {
-            IntelligentFlightManager.getInstance().addAutoSensingInfoListener(autoSensingInfoListener)
-            IntelligentFlightManager.getInstance().startAutoSensing(object : CommonCallbacks.CompletionCallback {
+            val manager = IntelligentFlightManager.getInstance()
+            if (!isAutoSensingListenerRegistered) {
+                manager.addAutoSensingInfoListener(autoSensingInfoListener)
+                isAutoSensingListenerRegistered = true
+            }
+            manager.startAutoSensing(object : CommonCallbacks.CompletionCallback {
                 override fun onSuccess() {
                     isAutoSensingActive = true
                     Log.i(TAG, "AutoSensing started")
                 }
                 override fun onFailure(error: IDJIError) {
+                    isAutoSensingActive = false
+                    removeAutoSensingListener()
                     Log.e(TAG, "AutoSensing start failed: ${error.description()}")
                 }
             })
@@ -718,24 +725,43 @@ class WildBridgeDefaultLayoutActivity : DefaultLayoutActivity() {
     }
 
     private fun stopAutoSensing() {
-        if (!isAutoSensingActive) return
+        clearAutoSensingState()
+        if (!isAutoSensingActive) {
+            removeAutoSensingListener()
+            return
+        }
         try {
             IntelligentFlightManager.getInstance().stopAutoSensing(object : CommonCallbacks.CompletionCallback {
                 override fun onSuccess() {
-                    isAutoSensingActive = false
-                    currentDetectedTargets = emptyList()
-                    TelemetryProvider.currentDetectedTargets = emptyList()
-                    mainHandler.post { detectionOverlay?.clearTargets() }
                     Log.i(TAG, "AutoSensing stopped")
                 }
                 override fun onFailure(error: IDJIError) {
                     Log.e(TAG, "AutoSensing stop failed: ${error.description()}")
                 }
             })
-            IntelligentFlightManager.getInstance().removeAutoSensingInfoListener(autoSensingInfoListener)
         } catch (e: Exception) {
             Log.e(TAG, "AutoSensing stop exception: ${e.message}")
+        } finally {
+            isAutoSensingActive = false
+            removeAutoSensingListener()
         }
+    }
+
+    private fun removeAutoSensingListener() {
+        if (!isAutoSensingListenerRegistered) return
+        try {
+            IntelligentFlightManager.getInstance().removeAutoSensingInfoListener(autoSensingInfoListener)
+        } catch (e: Exception) {
+            Log.e(TAG, "AutoSensing listener removal exception: ${e.message}")
+        } finally {
+            isAutoSensingListenerRegistered = false
+        }
+    }
+
+    private fun clearAutoSensingState() {
+        currentDetectedTargets = emptyList()
+        TelemetryProvider.currentDetectedTargets = emptyList()
+        mainHandler.post { detectionOverlay?.clearTargets() }
     }
 
     // ==================== End AutoSensing Toggle ====================

--- a/WildBridgeApp/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/core/ui/hsi/dashboard/AttitudeDashBoard.java
+++ b/WildBridgeApp/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/core/ui/hsi/dashboard/AttitudeDashBoard.java
@@ -303,7 +303,7 @@ public class AttitudeDashBoard extends ScrollableAttributeDashBoard {
     @Override
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
-        mCompositeDisposable.dispose();
+        mCompositeDisposable.clear();
     }
 
     @Override

--- a/WildBridgeApp/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/core/widget/hsi/AttitudeDisplayWidget.kt
+++ b/WildBridgeApp/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/core/widget/hsi/AttitudeDisplayWidget.kt
@@ -61,10 +61,12 @@ open class AttitudeDisplayWidget @JvmOverloads constructor(context: Context?, at
     }
 
     override fun onDetachedFromWindow() {
-        super.onDetachedFromWindow()
         if (!isInEditMode) {
+            mCompositeDisposable.clear()
             widgetModel.cleanup()
+            mAttitudeDashBoard?.setModel(null)
         }
+        super.onDetachedFromWindow()
     }
 
     private fun updateAltitude() {


### PR DESCRIPTION
Fixes the two LeakCanary retention paths observed in the Android app.

## Summary
- ensure AutoSensing listeners are removed even when startup fails before the feature is marked active
- clear HSI/AttitudeDisplay Rx subscriptions and dashboard model references on detach
- use `clear()` instead of `dispose()` for the reusable AttitudeDashBoard subscription container

## Validation
- `./gradlew :sample:compileDebugKotlin`
- `git diff --check`