### PR TITLE
Add H20T laser range finder (LRF) measurement endpoint

### DIFF
--- a/GroundStation/Python/djiInterface.py
+++ b/GroundStation/Python/djiInterface.py
@@ -75,6 +75,7 @@ EP_GOTO_TRAJECTORY = "/send/navigateTrajectory"
 EP_GOTO_ALTITUDE = "/send/gotoAltitude"
 EP_CAMERA_START_RECORDING = "/send/camera/startRecording"
 EP_CAMERA_STOP_RECORDING = "/send/camera/stopRecording"
+EP_LRF_MEASURE = "/send/lrf/measure"
 EP_GOTO_TRAJECTORY_DJI_NATIVE = "/send/navigateTrajectoryDJINative"
 EP_ABORT_DJI_NATIVE_MISSION = "/send/abort/DJIMission"
 EP_SET_RTH_ALTITUDE = "/send/setRTHAltitude"
@@ -378,6 +379,17 @@ class DJIInterface:
     def requestSendZoomRatio(self, zoomRatio=1):
         """Set camera zoom ratio."""
         return self.requestSend(EP_ZOOM, zoomRatio)
+
+    def requestLRFMeasure(self):
+        """Fire the H20T laser range finder once and return its reading."""
+        response = self.requestSend(EP_LRF_MEASURE, "")
+        if not response:
+            return {"distance": None, "target": None, "state": None}
+        try:
+            return json.loads(response)
+        except ValueError:
+            print(f"LRF: could not parse response: {response!r}")
+            return {"distance": None, "target": None, "state": None}
 
     def requestSendTakeOff(self):
         """Command the drone to take off."""

--- a/WildBridgeApp/android-sdk-v5-sample/src/main/java/dji/sampleV5/aircraft/WildBridgeDefaultLayoutActivity.kt
+++ b/WildBridgeApp/android-sdk-v5-sample/src/main/java/dji/sampleV5/aircraft/WildBridgeDefaultLayoutActivity.kt
@@ -41,6 +41,7 @@ import android.net.wifi.WifiManager
 import android.os.BatteryManager
 import androidx.core.app.ActivityCompat
 import dji.sampleV5.aircraft.controller.DroneController
+import dji.sampleV5.aircraft.controller.Payload
 import dji.v5.ux.detection.DetectedTarget
 import dji.v5.ux.detection.DetectionOverlayView
 import dji.sampleV5.aircraft.logger.WildBridgeFlightLogger
@@ -68,6 +69,7 @@ import dji.sdk.keyvalue.value.camera.CameraMode
 import dji.sdk.keyvalue.value.camera.CameraStorageInfos
 import dji.sdk.keyvalue.value.camera.CameraStorageLocation
 import dji.sdk.keyvalue.value.camera.SDCardLoadState
+import dji.sdk.keyvalue.value.camera.LaserMeasureState
 import dji.sdk.keyvalue.value.flightcontroller.FlightMode
 import dji.sdk.keyvalue.value.flightcontroller.LowBatteryRTHInfo
 import dji.sdk.keyvalue.value.gimbal.GimbalAngleRotation
@@ -1394,6 +1396,9 @@ class WildBridgeDefaultLayoutActivity : DefaultLayoutActivity() {
             // Cancel key listeners
             KeyManager.getInstance().cancelListen(this)
 
+            // Cancel H20T payload (LRF) key listeners
+            Payload.destroy()
+
             // Clean up DroneController listeners and resources
             DroneController.manualOverrideListener = null
             DroneController.droneStatusListener = null
@@ -2180,6 +2185,24 @@ class WildBridgeDefaultLayoutActivity : DefaultLayoutActivity() {
                     }
                     "/get/autoSensing/targets" -> {
                         DetectedTarget.listToJsonArray(currentDetectedTargets).toString()
+                    }
+                    // --- H20T Laser Range Finder (LRF) ---
+                    "/send/lrf/measure" -> {
+                        // Fire the laser and return distance + geo-reference + state as JSON.
+                        // distance and the target point are populated only when the laser locks
+                        // (state == NORMAL, which requires a GPS fix); other states return null
+                        // with the raw state.
+                        val info = Payload.takeFreshLrfReading()
+                        val state = info?.laserMeasureState
+                        val locked = state == LaserMeasureState.NORMAL
+                        val distance = if (locked) info?.distance else null
+                        val target = if (locked) info?.location3D?.takeIf {
+                            it.latitude != 0.0 || it.longitude != 0.0 || it.altitude != 0.0
+                        } else null
+                        val targetJson = if (target == null) "null"
+                            else "[${target.latitude}, ${target.longitude}, ${target.altitude}]"
+                        val stateJson = if (state == null) "null" else "\"$state\""
+                        "{\"distance\": ${distance ?: "null"}, \"target\": $targetJson, \"state\": $stateJson}"
                     }
                     else -> "Not Found: $uri"
                 }

--- a/WildBridgeApp/android-sdk-v5-sample/src/main/java/dji/sampleV5/aircraft/controller/Payload.kt
+++ b/WildBridgeApp/android-sdk-v5-sample/src/main/java/dji/sampleV5/aircraft/controller/Payload.kt
@@ -1,0 +1,101 @@
+package dji.sampleV5.aircraft.controller
+
+import android.util.Log
+import dji.sdk.keyvalue.key.CameraKey
+import dji.sdk.keyvalue.key.DJIKey
+import dji.sdk.keyvalue.value.camera.LaserMeasureInformation
+import dji.sdk.keyvalue.value.camera.LaserMeasureState
+import dji.sdk.keyvalue.value.camera.LaserWorkMode
+import dji.v5.et.create
+import dji.v5.et.get
+import dji.v5.et.listen
+import dji.v5.et.set
+import dji.v5.manager.KeyManager
+
+/**
+ * H20T payload control.
+ *
+ * Singleton so the HTTP endpoints in WildBridgeDefaultLayoutActivity can fire payload
+ * actions without holding payload-specific state in the activity. Blocking calls
+ * (e.g. takeFreshLrfReading) are invoked from the HTTP server's worker threads.
+ *
+ * Currently houses the Laser Range Finder (LRF); thermal capture will move here later.
+ */
+object Payload {
+
+    private const val TAG = "Payload"
+
+    // ==================== Laser Range Finder (LRF) ====================
+
+    private val laserKey: DJIKey<LaserWorkMode> = CameraKey.KeyLaserWorkMode.create()
+    private val laserMeasureKey: DJIKey<LaserMeasureInformation> = CameraKey.KeyLaserMeasureInformation.create()
+    private val lrfReadingLock = Any()
+
+    @Volatile
+    private var lrfInfo: LaserMeasureInformation? = null
+    @Volatile
+    private var lrfListenerRegistered: Boolean = false
+
+    // Register a persistent listener that caches the latest laser measurement. Idempotent.
+    private fun setupLaserMeasureListener() {
+        if (lrfListenerRegistered) return
+        // Cache the latest measurement as a fallback; takeFreshLrfReading polls the key directly.
+        laserMeasureKey.listen(this) { newValue: LaserMeasureInformation? ->
+            lrfInfo = newValue
+        }
+        lrfListenerRegistered = true
+        Log.i(TAG, "LRF measure listener registered")
+    }
+
+    // Fire the laser, wait for a fresh measurement, then turn the laser off.
+    // Blocking, call from a worker thread.
+    fun takeFreshLrfReading(timeoutMs: Long = 2000L): LaserMeasureInformation? = synchronized(lrfReadingLock) {
+        setupLaserMeasureListener()
+        lrfInfo = null
+
+        try {
+            laserKey.set(
+                LaserWorkMode.OPEN_ALWAYS,
+                onSuccess = { Log.i(TAG, "LRF laser opened") },
+                onFailure = { error -> Log.e(TAG, "LRF laser open failed: ${error.description()}") }
+            )
+
+            // Poll the key directly for fresh values; wait for the laser to lock (state == NORMAL)
+            val deadline = System.currentTimeMillis() + timeoutMs
+            var reading: LaserMeasureInformation? = null
+            while (System.currentTimeMillis() < deadline) {
+                val current = laserMeasureKey.get() ?: lrfInfo
+                if (current != null) {
+                    reading = current
+                    if (current.laserMeasureState == LaserMeasureState.NORMAL) break
+                }
+                try {
+                    Thread.sleep(50)
+                } catch (e: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                    break
+                }
+            }
+            if (reading == null) {
+                Log.w(TAG, "LRF reading timed out after ${timeoutMs}ms (no data from laser)")
+            } else {
+                Log.i(TAG, "LRF reading: ${reading.distance} m, state=${reading.laserMeasureState}")
+            }
+            reading
+        } finally {
+            // Return the laser to on-demand (closed)
+            laserKey.set(
+                LaserWorkMode.OPEN_ON_DEMAND,
+                onSuccess = { Log.i(TAG, "LRF laser set to OPEN_ON_DEMAND (off)") },
+                onFailure = { error -> Log.e(TAG, "LRF laser close failed: ${error.description()}") }
+            )
+        }
+    }
+
+    // Cancel payload key listeners. Call from the host activity's onDestroy.
+    fun destroy() {
+        KeyManager.getInstance().cancelListen(this)
+        lrfListenerRegistered = false
+        lrfInfo = null
+    }
+}


### PR DESCRIPTION
POST /send/lrf/measure fires the H20T laser once and returns {distance, target, state} as JSON. distance (metres) and the geo-referenced target point are returned only when the laser locks (state == NORMAL, which requires a GPS fix); other states return null with the raw state. The laser is always restored to OPEN_ON_DEMAND.