### PR TITLE
add support for DJI Mini 5 Pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Each drone connects to its RC via DJI OcuSync (2.4/5 GHz). The RC connects to th
 ### DJI Drones
 - DJI Mini 3 / Mini 3 Pro
 - DJI Mini 4 Pro
+- DJI Mini 5 Pro
 - DJI Mavic 3 Enterprise Series (M3E)
 - DJI Matrice 30 Series (M30/M30T)
 - DJI Matrice 300 RTK
@@ -76,7 +77,7 @@ The left-side WildBridge panel provides the controls most often used during rese
 - **AI DETECT** toggles DJI AutoSensing detection and shows bounding boxes on the FPV view where supported by the aircraft and SDK.
 - **AUTO / MANUAL** is the manual override switch. In **AUTO** mode, WildBridge accepts autonomous HTTP commands such as waypoints, trajectories, and virtual-stick navigation. Switching it to **MANUAL** activates the override latch, disables virtual stick, stops active control loops, and rejects new autonomous commands until the switch is cleared or `/send/deactivateManualOverride` is called.
 - The manual override latch can also activate automatically while an autonomous control loop is running if RC stick input exceeds the configured deadzone. This lets the pilot take over immediately.
-- **CTRL MINI4**, **CTRL M350**, or **CTRL MAVIC3** shows the detected control profile. WildBridge selects this profile from the DJI product type and uses it to choose conservative speed and PID parameters for the aircraft class.
+- **CTRL MINI4**, **CTRL MINI5**, **CTRL M350**, or **CTRL MAVIC3** shows the detected control profile. WildBridge selects this profile from the DJI product type and uses it to choose conservative speed and PID parameters for the aircraft class.
 - The lower status strip shows the configured drone name, WildBridge state, altitude, selected control profile, and current video sender diagnostics.
 
 The WebRTC line at the bottom is a compact sender-health readout. It reports stream state, output resolution, requested resolution, source resolution, output FPS versus target FPS, dropped FPS, frame resize/processing time, scaling mode, processing errors, and recovery count. The same metrics are included in the telemetry stream under `webRtc`, so the GroundStation dashboard can show sender FPS and processing health without relying only on browser-side receive statistics.

--- a/WildBridgeApp/android-sdk-v5-sample/src/main/java/dji/sampleV5/aircraft/DroneControlProfiles.kt
+++ b/WildBridgeApp/android-sdk-v5-sample/src/main/java/dji/sampleV5/aircraft/DroneControlProfiles.kt
@@ -48,6 +48,17 @@ enum class DroneControlProfile(
         yawKp = 3.0,
         maxYawRateDegS = 30.0,
         defaultCruiseSpeedMps = 2.0
+    ),
+    MINI_5_PRO(
+        displayName = "DJI Mini 5 Pro",
+        maxHorizontalSpeedMps = 15.0,
+        maxGotoWpSpeedMps = 5.0,
+        distanceKp = 0.65,
+        distanceKi = 0.0001,
+        distanceKd = 0.001,
+        yawKp = 3.0,
+        maxYawRateDegS = 30.0,
+        defaultCruiseSpeedMps = 2.0
     )
 }
 
@@ -65,6 +76,9 @@ object DroneControlProfiles {
 
             name.contains("MINI_4", ignoreCase = true) ||
             name.contains("MINI4", ignoreCase = true) -> DroneControlProfile.MINI_4_PRO
+
+            name.contains("MINI_5", ignoreCase = true) ||
+            name.contains("MINI5", ignoreCase = true) -> DroneControlProfile.MINI_5_PRO
 
             name.contains("MAVIC_3", ignoreCase = true) ||
             name.contains("MAVIC3", ignoreCase = true) ||

--- a/WildBridgeApp/android-sdk-v5-sample/src/main/java/dji/sampleV5/aircraft/WildBridgeDefaultLayoutActivity.kt
+++ b/WildBridgeApp/android-sdk-v5-sample/src/main/java/dji/sampleV5/aircraft/WildBridgeDefaultLayoutActivity.kt
@@ -647,6 +647,7 @@ class WildBridgeDefaultLayoutActivity : DefaultLayoutActivity() {
         val controlLabel = when (controlProfile) {
             DroneControlProfile.MATRICE_350_RTK -> "CTRL M350"
             DroneControlProfile.MINI_4_PRO -> "CTRL MINI4"
+            DroneControlProfile.MINI_5_PRO -> "CTRL MINI5"
             DroneControlProfile.MAVIC_3_ENTERPRISE -> "CTRL MAVIC3"
         }
         findViewById<TextView>(R.id.text_control_profile)?.text = controlLabel


### PR DESCRIPTION
This adds support for the DJI Mini 5 Pro.

Currently untested and therefore a draft for early comments.